### PR TITLE
Tongue-in-cheek

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -111,7 +111,7 @@ AGAGAAB/HgAAf44AAGAGAABgBgAAYAYAAD/8AACAAQAA" />
             
 
             <p>
-              <a href="https://gun.io"><img src="https://camo.githubusercontent.com/b664dc146e60153497166bacf0e800c2604da9c8/687474703a2f2f692e696d6775722e636f6d2f4d37774a6970522e706e67" alt="Made by Gun.io" data-canonical-src="http://i.imgur.com/M7wJipR.png" style="max-width:70%;"></a>
+              <a href="https://www.gun.io"><img src="https://camo.githubusercontent.com/b664dc146e60153497166bacf0e800c2604da9c8/687474703a2f2f692e696d6775722e636f6d2f4d37774a6970522e706e67" alt="Made by Gun.io" data-canonical-src="http://i.imgur.com/M7wJipR.png" style="max-width:70%;"></a>
             </p>
 
 


### PR DESCRIPTION
Hi, just to let you know that gun.io (without www.) is wonky. http://gun.io sometimes redirects to https://www.gun.io, sometimes it doesn't  do anything, sometimes it redirects to a random path on http://gun.io/.
https://gun.io/ doesn't work most of the time.
https://www.gun.io/ mostly works.

I'd fix the without-www endpoint too though.